### PR TITLE
レビュー⑥ 「3-3-5 削除機能を実装する」まで

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -21,6 +21,13 @@ class TasksController < ApplicationController
   end
 
   def edit
+    @task = Task.find(params[:id])
+  end
+
+  def update
+    task = Task.find(params[:id])
+    task.update!(task_params)
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -30,6 +30,14 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
+  def destroy
+    task = Task.find(params[:id])
+    task.destroy
+    # Rails7からレスポンスのリダイレクトにstatus: :see_otherをつける必要があるようです。
+    # https://qiita.com/jnchito/items/5c41a7031404c313da1f#destroy%E3%81%AE%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9%E3%81%AB-status-see_other-%E3%82%92%E4%BB%98%E3%81%91%E3%82%8B%E5%BF%85%E8%A6%81%E3%81%8C%E3%81%82%E3%82%8B
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。", status: :see_other
+  end
+
   private
 
   def task_params

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,0 +1,8 @@
+= form_with model: task, local: true do |f|
+  .mb-3
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .mb-3
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,2 +1,13 @@
-h1 Tasks#edit
-p Find me in app/views/tasks/edit.html.slim
+h1 タスクの編集
+
+.nav.justify-content-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+= form_with model: @task, local: true do |f|
+  .mb
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+  .mb
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -3,11 +3,4 @@ h1 タスクの編集
 .nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .mb
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .mb
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -15,4 +15,7 @@ table.table.table-hover
         td = link_to task.name, task
         td = task.created_at
         td
-          = link_to '編集', edit_task_path(task), class: 'btn btn-primary me3'
+          = link_to '編集', edit_task_path(task), class: 'btn btn-primary me-3'
+          / = link_to '削除', task, method: :delete, data: { confirm: "タスク「#{task.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger'
+          / 書籍では上の通り。下はTurboを使っている場合
+          = link_to '削除', task, data: { turbo_confirm: "タスク「#{task.name}」を削除します。よろしいですか？", turbo_method: :delete}, class: 'btn btn-danger'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -8,8 +8,11 @@ table.table.table-hover
     tr
       th = Task.human_attribute_name(:name)
       th = Task.human_attribute_name(:created_at)
+      th
   tbody
     - @tasks.each do |task|
       tr
         td = link_to task.name, task
         td = task.created_at
+        td
+          = link_to '編集', edit_task_path(task), class: 'btn btn-primary me3'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -1,13 +1,6 @@
 h1 タスクの新規登録
 
-.nav.justify-content-end 
+.nav.justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .mb-3
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-  .mb-3
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -20,4 +20,5 @@ table.table.table-hover
       th = Task.human_attribute_name(:updated_at)
       td = @task.updated_at
 
-= link_to '編集', edit_task_path, class: 'btn btn-primary me3'
+= link_to '編集', edit_task_path, class: 'btn btn-primary me-3'
+= link_to '削除', @task, data: { turbo_confirm: "タスク「#{@task.name}」を削除します。よろしいですか？", turbo_method: :delete}, class: 'btn btn-danger'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -19,3 +19,5 @@ table.table.table-hover
     tr
       th = Task.human_attribute_name(:updated_at)
       td = @task.updated_at
+
+= link_to '編集', edit_task_path, class: 'btn btn-primary me3'


### PR DESCRIPTION
## 概要
- タスクの編集機能の実装
- 編集画面と新規作成画面のフォーム部分の共通化（views/tasks/_from.html.slimの追加）
- タスクの削除機能の実装（一覧画面、詳細画面）

## 本書の範囲
- 3-3-4 編集機能を実装する
- 3-3-5 削除機能を実装する

## 画面キャプチャ
![スクリーンショット 2023-07-12 14 11 06](https://github.com/hikarook94/taskleaf/assets/59002337/4f1be4f8-c7f2-4401-a4e2-234eb632db2f)

![スクリーンショット 2023-07-12 11 47 56](https://github.com/hikarook94/taskleaf/assets/59002337/9f35f827-26aa-41ef-9b06-efe50a9b8f5e)

![スクリーンショット 2023-07-12 13 49 43](https://github.com/hikarook94/taskleaf/assets/59002337/2c7467a2-c2b4-49ea-b31a-44e966a6b7f3)

![スクリーンショット 2023-07-12 13 49 54](https://github.com/hikarook94/taskleaf/assets/59002337/85e70f9e-d672-4d2d-89df-f0873f8d9b98)

