### PR TITLE
レビュー8 「4-5 ログイン機能を作る」まで

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
+    bcrypt (3.1.19)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -240,6 +241,7 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   bootstrap
   capybara

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,13 @@
+class Admin::UsersController < ApplicationController
+  def new
+  end
+
+  def edit
+  end
+
+  def show
+  end
+
+  def index
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,6 @@
 class Admin::UsersController < ApplicationController
+  before_action :require_admin
+
   def index
     @users = User.all
   end
@@ -45,5 +47,9 @@ class Admin::UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+  end
+
+  def require_admin
+    redirect_to root_url unless current_user.admin?
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,16 @@
 class Admin::UsersController < ApplicationController
   def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を登録しました。"
+    else
+      render :new
+    end
   end
 
   def edit
@@ -9,5 +20,11 @@ class Admin::UsersController < ApplicationController
   end
 
   def index
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,18 @@
 class Admin::UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+
   def new
     @user = User.new
+  end
+
+  def edit
+    @user = User.find(params[:id])
   end
 
   def create
@@ -13,13 +25,20 @@ class Admin::UsersController < ApplicationController
     end
   end
 
-  def edit
+  def update
+    @user = User.find(params)
+
+    if @user.update
+      redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を更新しました。"
+    else
+      render :edit
+    end
   end
 
-  def show
-  end
-
-  def index
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    redirect_to admin_users_url, notice: "ユーザー「#{@user.name}」を削除しました。", status: :see_other
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -28,9 +28,9 @@ class Admin::UsersController < ApplicationController
   end
 
   def update
-    @user = User.find(params)
+    @user = User.find(params[:id])
 
-    if @user.update
+    if @user.update(user_params)
       redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を更新しました。"
     else
       render :edit

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  helper_method :current_user
+
+  private
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,14 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user
+  before_action :login_required
 
   private
 
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def login_required
+    redirect_to login_url unless current_user
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,4 @@
+class SessionsController < ApplicationController
+  def new
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,26 @@
 class SessionsController < ApplicationController
   def new
   end
+
+  def create
+    user = User.find_by(email: session_params[:email])
+
+    if user&.authenticate(session_params[:password])
+      session[:user_id] = user.id
+      redirect_to root_url, notice: 'ログインしました。'
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    reset_session
+    redirect_to root_url, notice: 'ログアウトしました。'
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email, :password)
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :login_required
+
   def new
   end
 
@@ -15,7 +17,7 @@ class SessionsController < ApplicationController
 
   def destroy
     reset_session
-    redirect_to root_url, notice: 'ログアウトしました。'
+    redirect_to root_url, notice: 'ログアウトしました。', status: :see_other
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,10 +1,11 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    # @tasks = Task.where(user_id: current_user.id)
+    @tasks = current_user.tasks
   end
 
   def show
-    @task = Task.find(params[:id])
+    @task = current_user.tasks.find(params[:id])
   end
 
   def new
@@ -12,7 +13,8 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
+    # @task = Task.new(task_params.merge(user_id: current_user.id))
+    @task = current_user.tasks.new(task_params)
 
     if @task.save
       redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。"
@@ -22,17 +24,17 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = Task.find(params[:id])
+    @task = current_user.tasks.find(params[:id])
   end
 
   def update
-    task = Task.find(params[:id])
+    task = current_user.tasks.find(params[:id])
     task.update!(task_params)
     redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
   def destroy
-    task = Task.find(params[:id])
+    task = current_user.tasks.find(params[:id])
     task.destroy
     # Rails7からレスポンスのリダイレクトにstatus: :see_otherをつける必要があるようです。
     # https://qiita.com/jnchito/items/5c41a7031404c313da1f#destroy%E3%81%AE%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9%E3%81%AB-status-see_other-%E3%82%92%E4%BB%98%E3%81%91%E3%82%8B%E5%BF%85%E8%A6%81%E3%81%8C%E3%81%82%E3%82%8B

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,8 @@ class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
   validate :validate_name_not_including_comma
 
+  belongs_to :user
+
   private
 
   def validate_name_not_including_comma

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
+
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
+
+  has_many :tasks
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+  has_secure_password
 end

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,0 +1,24 @@
+- if user.errors.present?
+  ul#error_explanation
+    - user.errors.full_messages.each do |message|
+      li = message
+
+= form_with model: [:admin, user], local: true do |f|
+  .mb-3
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .mb-3
+    = f.label :email, 'メールアドレス'
+    = f.email_field :email, class: 'form-control'
+  .form-check
+    = f.label :admin, class: 'form-check-label' do
+      = f.check_box :admin, class: 'form-check-input'
+      | 管理者情報
+  .mb-3
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control'
+  .mb-3
+    = f.label :password_confirmation, 'パスワード (確認)'
+    = f.password_field :password_confirmation, class: 'form-control'
+
+  = f.submit '登録する', class: 'btn btn-primary'

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Users#edit
+p Find me in app/views/admin/users/edit.html.slim

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,2 +1,6 @@
-h1 Admin::Users#edit
-p Find me in app/views/admin/users/edit.html.slim
+h1 ユーザーの編集
+
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+
+= render partial: "form", locals: {user: @user}

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Users#index
+p Find me in app/views/admin/users/index.html.slim

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,2 +1,28 @@
-h1 Admin::Users#index
-p Find me in app/views/admin/users/index.html.slim
+h1 ユーザー一覧
+
+= link_to '新規登録', new_admin_user_path, class: 'btn btn-primary'
+
+.mb-3
+table.table.table-hover
+  thead.thead-default
+    tr
+      th = User.human_attribute_name(:name)
+      th = User.human_attribute_name(:email)
+      th = User.human_attribute_name(:admin)
+      th = User.human_attribute_name(:created_at)
+      th = User.human_attribute_name(:updated_at)
+      th
+  tbody
+    - @users.each do |user|
+      tr
+        td = link_to user.name, [:admin, user]
+        td = user.email
+        td = user.admin ? 'あり' : 'なし'
+        td = user.created_at
+        td = user.updated_at
+        td
+          = link_to '編集', edit_admin_user_path(user), class: 'btn btn-primary me-3'
+          = link_to '削除', [:admin, user],
+            data: { confirm: 'Are you sure?', turbo_action: 'replace' },
+            data: { turbo_confirm: "ユーザー「#{user.name}」を削除します。よろしいですか？", turbo_method: :delete},
+            class: 'btn btn-danger'

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -23,6 +23,5 @@ table.table.table-hover
         td
           = link_to '編集', edit_admin_user_path(user), class: 'btn btn-primary me-3'
           = link_to '削除', [:admin, user],
-            data: { confirm: 'Are you sure?', turbo_action: 'replace' },
             data: { turbo_confirm: "ユーザー「#{user.name}」を削除します。よろしいですか？", turbo_method: :delete},
             class: 'btn btn-danger'

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Users#new
+p Find me in app/views/admin/users/new.html.slim

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,21 +1,6 @@
 h1 ユーザー登録
 
-= form_with model: [:admin, @user], local: true do |f|
-  .mb-3
-    = f.label :name, '名前'
-    = f.text_field :name, class: 'form-control'
-  .mb-3
-    = f.label :email, 'メールアドレス'
-    = f.email_field :email, class: 'form-control'
-  .form-check
-    = f.label :admin, class: 'form-check-label' do
-      = f.check_box :admin, class: 'form-check-input'
-      | 管理者情報
-  .mb-3
-    = f.label :password, 'パスワード'
-    = f.password_field :password, class: 'form-control'
-  .mb-3
-    = f.label :password_confirmation, 'パスワード (確認)'
-    = f.password_field :password_confirmation, class: 'form-control'
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
 
-  = f.submit '登録する', class: 'btn btn-primary'
+= render partial: "form", locals: {user: @user}

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,2 +1,21 @@
-h1 Admin::Users#new
-p Find me in app/views/admin/users/new.html.slim
+h1 ユーザー登録
+
+= form_with model: [:admin, @user], local: true do |f|
+  .mb-3
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .mb-3
+    = f.label :email, 'メールアドレス'
+    = f.email_field :email, class: 'form-control'
+  .form-check
+    = f.label :admin, class: 'form-check-label' do
+      = f.check_box :admin, class: 'form-check-input'
+      | 管理者情報
+  .mb-3
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control'
+  .mb-3
+    = f.label :password_confirmation, 'パスワード (確認)'
+    = f.password_field :password_confirmation, class: 'form-control'
+
+  = f.submit '登録する', class: 'btn btn-primary'

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Users#show
+p Find me in app/views/admin/users/show.html.slim

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,2 +1,29 @@
-h1 Admin::Users#show
-p Find me in app/views/admin/users/show.html.slim
+h1 ユーザーの詳細
+
+.nav.justify-content-end
+  = link_to '一覧', admin_users_path, class: 'nav-link'
+
+table.table.table-hover
+  tbody
+    tr
+      th = User.human_attribute_name(:name)
+      td = @user.name
+    tr
+      th = User.human_attribute_name(:email)
+      td = @user.email
+    tr
+      th = User.human_attribute_name(:admin)
+      td= @user.admin ? 'あり' : 'なし'
+    tr
+      th = User.human_attribute_name(:created_at)
+      td= @user.created_at
+    tr
+      th = User.human_attribute_name(:updated_at)
+      td= @user.updated_at
+
+
+= link_to '編集', edit_admin_user_path(@user), class: 'btn btn-primary me-3'
+= link_to '削除', [:admin, @user],
+  data: { confirm: 'Are you sure?', turbo_action: 'replace' },
+  data: { turbo_confirm: "ユーザー「#{@user.name}」を削除します。よろしいですか？", turbo_method: :delete},
+  class: 'btn btn-danger'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -16,7 +16,9 @@ html
         - if current_user
           li.nav-item = link_to 'タスク一覧', tasks_path, class: 'nav-link'
           li.nav-item = link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
-          li.nav-item = link_to 'ログアウト', logout_path, method: :delete, class: 'nav-link'
+          li.nav-item = link_to 'ログアウト', logout_path,
+            data: {turbo_method: :delete},
+            class: 'nav-link'
         - else
           li.nav-time = link_to 'ログイン', login_path, class: 'nav-link'
     .container

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,6 +11,14 @@ html
   body
     .app-title.navbar.navbar-expand-md.navbar-light.bg-light
       .navbar-brand Taskleaf
+
+      ul.navbar-nav.ml-auto
+        - if current_user
+          li.nav-item = link_to 'タスク一覧', tasks_path, class: 'nav-link'
+          li.nav-item = link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
+          li.nav-item = link_to 'ログアウト', logout_path, method: :delete, class: 'nav-link'
+        - else
+          li.nav-time = link_to 'ログイン', login_path, class: 'nav-link'
     .container
       - if flash.notice.present?
         .alert.alert-success = flash.notice

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -15,7 +15,8 @@ html
       ul.navbar-nav.ml-auto
         - if current_user
           li.nav-item = link_to 'タスク一覧', tasks_path, class: 'nav-link'
-          li.nav-item = link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
+          - if current_user.admin?
+            li.nav-item = link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
           li.nav-item = link_to 'ログアウト', logout_path,
             data: {turbo_method: :delete},
             class: 'nav-link'

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -1,0 +1,2 @@
+h1 Sessions#new
+p Find me in app/views/sessions/new.html.slim

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -1,2 +1,10 @@
-h1 Sessions#new
-p Find me in app/views/sessions/new.html.slim
+h1 ログイン
+
+= form_with scope: :session, local: true do |f|
+  .mb-3
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control', id: 'session_email'
+  .mb-3
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control', id: 'session_password'
+  = f.submit 'ログインする', class: 'btn btn-primary'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,14 @@ ja:
         description: 詳しい説明
         created_at: 登録日時
         updated_at: 更新日時
+      user:
+        id: ID
+        name: 名前
+        admin: 管理者権限
+        password: パスワード
+        password_confirmation: パスワード（確認）
+        created_at: 登録日時
+        updated_at: 更新日時
   date:
     abbr_day_names:
     - 日
@@ -26,7 +34,7 @@ ja:
     - 金
     - 土
     abbr_month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -52,7 +60,7 @@ ja:
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
     month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'sessions/new'
   namespace :admin do
     resources :users
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get 'sessions/new'
+  get '/login', to: 'sessions#new'
   namespace :admin do
     resources :users
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,13 @@
 Rails.application.routes.draw do
+  root to: 'tasks#index'
   get '/login', to: 'sessions#new'
+  post '/login', to: 'sessions#create'
+  delete '/logout', to: 'sessions#destroy'
   namespace :admin do
     resources :users
   end
 
   resources :tasks
-  root to: 'tasks#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    get 'users/new'
+    get 'users/edit'
+    get 'users/show'
+    get 'users/index'
+  end
   resources :tasks
   root to: 'tasks#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,8 @@
 Rails.application.routes.draw do
   namespace :admin do
-    get 'users/new'
-    get 'users/edit'
-    get 'users/show'
-    get 'users/index'
+    resources :users
   end
+
   resources :tasks
   root to: 'tasks#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20230713080953_create_users.rb
+++ b/db/migrate/20230713080953_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+      t.index :email, unique: true
+    end
+  end
+end

--- a/db/migrate/20230714011242_add_admin_to_users.rb
+++ b/db/migrate/20230714011242_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20230714084419_add_user_id_to_tasks.rb
+++ b/db/migrate/20230714084419_add_user_id_to_tasks.rb
@@ -1,0 +1,10 @@
+class AddUserIdToTasks < ActiveRecord::Migration[7.0]
+  def up
+    execute 'DELETE FROM tasks;'
+    add_reference :tasks, :user, null: false, index: true
+  end
+
+  def down
+    remove_reference :tasks, :user, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_11_013652) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_13_080953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_11_013652) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_13_080953) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_14_011242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_080953) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_14_011242) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_14_084419) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_14_011242) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get admin_users_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get admin_users_edit_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get admin_users_show_url
+    assert_response :success
+  end
+
+  test "should get index" do
+    get admin_users_index_url
+    assert_response :success
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get sessions_new_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  email: MyString
+  password_digest: MyString
+
+two:
+  name: MyString
+  email: MyString
+  password_digest: MyString

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- Userモデル作成
- ユーザー管理機能（ユーザーCRUD）追加
- ログイン機能追加
  - bcrypt gem追加
- ログインユーザーと紐づくタスクだけ表示するように変更
- ユーザー管理機能が管理者ユーザーにだけ使えるように変更
  - 一般ユーザーが`/admin/`以下にアクセスしてもRootにリダイレクトする

## 画面キャプチャ
![スクリーンショット 2023-07-14 15 29 19](https://github.com/hikarook94/taskleaf/assets/59002337/a30537c4-2c28-4854-a4ce-bb5847410c56)

![スクリーンショット 2023-07-14 13 00 23](https://github.com/hikarook94/taskleaf/assets/59002337/abb3b3de-feca-433e-80b5-00e839a4b859)

![スクリーンショット 2023-07-14 13 43 27](https://github.com/hikarook94/taskleaf/assets/59002337/1fd906b7-8191-4b5a-84c3-a142ffc699ce)

![スクリーンショット 2023-07-14 15 03 28](https://github.com/hikarook94/taskleaf/assets/59002337/8b256828-d204-440e-92c3-b497c201f611)
