### PR TITLE
レビュー⑨ 「4-10 詳しい説明に含まれるURLをリンクとして表示する」まで

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem 'slim-rails'
 gem 'html2slim'
 gem 'bootstrap'
+gem 'rails_autolink'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,10 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails_autolink (1.1.8)
+      actionview (> 3.1)
+      activesupport (> 3.1)
+      railties (> 3.1)
     railties (7.0.6)
       actionpack (= 7.0.6)
       activesupport (= 7.0.6)
@@ -252,6 +256,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.5, >= 7.0.5.1)
+  rails_autolink
   selenium-webdriver
   slim-rails
   sprockets-rails

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,11 +1,13 @@
 class TasksController < ApplicationController
+  before_action :set_task, only: [:show, :edit, :update, :destroy]
+
   def index
     # @tasks = Task.where(user_id: current_user.id)
-    @tasks = current_user.tasks
+    # @tasks = current_user.tasks.order(created_at: :desc)
+    @tasks = current_user.tasks.recent
   end
 
   def show
-    @task = current_user.tasks.find(params[:id])
   end
 
   def new
@@ -24,26 +26,27 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = current_user.tasks.find(params[:id])
   end
 
   def update
-    task = current_user.tasks.find(params[:id])
-    task.update!(task_params)
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
+    @task.update!(task_params)
+    redirect_to tasks_url, notice: "タスク「#{@task.name}」を更新しました。"
   end
 
   def destroy
-    task = current_user.tasks.find(params[:id])
-    task.destroy
+    @task.destroy
     # Rails7からレスポンスのリダイレクトにstatus: :see_otherをつける必要があるようです。
     # https://qiita.com/jnchito/items/5c41a7031404c313da1f#destroy%E3%81%AE%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9%E3%81%AB-status-see_other-%E3%82%92%E4%BB%98%E3%81%91%E3%82%8B%E5%BF%85%E8%A6%81%E3%81%8C%E3%81%82%E3%82%8B
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。", status: :see_other
+    redirect_to tasks_url, notice: "タスク「#{@task.name}」を削除しました。", status: :see_other
   end
 
   private
 
   def task_params
     params.require(:task).permit(:name, :description)
+  end
+
+  def set_task
+    @task = current_user.tasks.find(params[:id])
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,6 +5,8 @@ class Task < ApplicationRecord
 
   belongs_to :user
 
+  scope :recent, -> {order(created_at: :desc)}
+
   private
 
   def validate_name_not_including_comma

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -12,7 +12,7 @@ table.table.table-hover
       td = @task.name
     tr
       th = Task.human_attribute_name(:description)
-      td = simple_format(h(@task.description), {}, sanitize: false, wrapper_tag: "div")
+      td = auto_link(simple_format(h(@task.description), {}, sanitize: false, wrapper_tag: "div"))
     tr
       th = Task.human_attribute_name(:created_at)
       td = @task.created_at


### PR DESCRIPTION
## 概要
- タスク一覧のタスクを新しい順に指定
- タスク詳細の詳しい説明欄にURLがあるときにリンク化する
  - auto_link gem追加

## 画面キャプチャ
![スクリーンショット 2023-07-18 14 51 48](https://github.com/hikarook94/taskleaf/assets/59002337/020bef69-c9cd-4b80-9987-4fd4f9ec2857)
